### PR TITLE
feat: all api.cyoatta.xyz requests are now routed to cyoatta.xyz:4209…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
 FROM nginx:latest
 
-# File Author / Maintainer
 LABEL authors="Alexandru Florian Barascu <alex.florin2352@gmail.com>"
 MAINTAINER alex.florin2352@gmail.com
-
-ENV PORT=80
 
 WORKDIR /usr/share/nginx/html
 
 COPY ./build /usr/share/nginx/html
 COPY ./config/default.conf /etc/nginx/conf.d/default.conf
-# COPY ./config/nginx.conf /etc/nginx/nginx.conf
 
 COPY ./config/ssl.conf /config/nginx/ssl.conf
-# COPY ./certs/fullchain.pem /config/keys/letsencrypt/fullchain.pem
-# COPY ./certs/privkey.pem /config/keys/letsencrypt/privkey.pem
+COPY ./config/compression.conf /config/nginx/compression.conf
 
-EXPOSE $PORT
+EXPOSE 80 443
 
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/config/compression.conf
+++ b/config/compression.conf
@@ -1,9 +1,19 @@
 gzip on;
-gzip_http_version 1.1;
-gzip_vary on;
+gzip_disable "msie6";
+
 gzip_comp_level 6;
+gzip_min_length 1100;
+gzip_buffers 16 8k;
 gzip_proxied any;
-gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xm
-l+rss text/javascript application/javascript text/x-js;
-gzip_buffers 16 32k;
-gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+gzip_types
+    text/plain
+    text/css
+    text/js
+    text/xml
+    text/javascript
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/rss+xml
+    image/svg+xml;

--- a/config/default.conf
+++ b/config/default.conf
@@ -7,8 +7,26 @@ server {
 }
 
 server {
+    listen 443 ssl http2; ## listen for ipv4; this line is default and implied
+    listen [::]:443 http2; ## listen for ipv6
+
+    error_log /var/log/nginx/custom_error.log;
+
+    server_tokens off; # disable the Server nginx header
+
+    server_name api.cyoatta.xyz; # all hostnames
+
+    include /config/nginx/ssl.conf;
+    include /config/nginx/compression.conf;
+
+    location / {
+        proxy_pass https://cyoatta.xyz:4209;
+    }
+}
+
+server {
     listen   443 ssl http2; ## listen for ipv4; this line is default and implied
-    listen   [::]:443 http2 ipv6only=on; ## listen for ipv6
+    listen   [::]:443 http2; ## listen for ipv6
 
     root /usr/share/nginx/html;
     index index.html;
@@ -17,30 +35,10 @@ server {
 
     server_tokens off; # disable the Server nginx header
 
-    server_name _; # all hostnames
+    server_name .cyoatta.xyz;
 
     include /config/nginx/ssl.conf;
-
-    # enable gzip
-    gzip on;
-    gzip_disable "msie6";
-
-    gzip_comp_level 6;
-    gzip_min_length 1100;
-    gzip_buffers 16 8k;
-    gzip_proxied any;
-    gzip_types
-        text/plain
-        text/css
-        text/js
-        text/xml
-        text/javascript
-        application/javascript
-        application/x-javascript
-        application/json
-        application/xml
-        application/rss+xml
-        image/svg+xml;
+    include /config/nginx/compression.conf;
 
     location / {
         try_files $uri /index.html; # redirect all request to index.html

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,9 +1,0 @@
-events {
-}
-
-http {
-    ssl_certificate /home/nomercy235/projects/cyoa/cyoa-backend/fullchain.pem;
-    ssl_certificate_key /home/nomercy235/projects/cyoa/cyoa-backend/privkey.pem;
-    ssl_ciphers EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH;
-    ssl_protocols TLSv1.1 TLSv1.2;
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 
 services:
-  cyoa:
-    container_name: cyoa-frontend
+  rigamo:
+    container_name: rigamo-frontend
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
… via proxy_pass. This was done to relief the frontend of having to know the port on which the backend was deployed (#12)

chore: refactored some of the nginx configuration and removed unused files

chore: small refactoring for Dockerfile